### PR TITLE
lazily evaluate and escape text and attributes

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -1,3 +1,7 @@
+// COULD JUST USE ENUMS AS FUNCTIONS
+// LAZILY ESCAPE ATTRIBUTES OR RETURN ERRORS LATER
+//
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Component {
     Text(String),


### PR DESCRIPTION
Lazily evaluate text and attributes. Escape chars and return errors on render.